### PR TITLE
Map the ID of area types allowing it to be referenced in filters.

### DIFF
--- a/importer/hierarchy.go
+++ b/importer/hierarchy.go
@@ -52,12 +52,7 @@ func mapAreas(rawArea json.RawMessage) []*model.Area {
 		}
 
 		var results []*model.Area
-
-		area := &model.Area{
-			Title: wdaArea.Labels.Label[0].Text,
-			Type:  wdaArea.AreaType.Codename,
-		}
-
+		area := mapArea(wdaArea)
 		results = append(results, area)
 		return results
 
@@ -66,13 +61,17 @@ func mapAreas(rawArea json.RawMessage) []*model.Area {
 		var results []*model.Area
 
 		for _, wdaArea := range wdaAreaArray {
-
-			area := &model.Area{
-				Title: wdaArea.Labels.Label[0].Text,
-				Type:  wdaArea.AreaType.Codename,
-			}
+			area := mapArea(wdaArea)
 			results = append(results, area)
 		}
 		return results
 	}
+}
+func mapArea(wdaArea wda.Area) *model.Area {
+	area := &model.Area{
+		Title:  wdaArea.Labels.Label[0].Text,
+		Type:   wdaArea.AreaType.Codename,
+		TypeId: wdaArea.AreaType.Abbreviation,
+	}
+	return area
 }


### PR DESCRIPTION
### What

Map the ID of area types allowing it to be referenced in filters.

### How to review

- delete the areas index
- re-import the updated template
- re-import the hierarchies
- check the areas in elasticsearch have a populated type ID.

### Who can review

@githubmo 
